### PR TITLE
Add docs/ landing page and update preview.html links

### DIFF
--- a/.github/workflows/preview-link.yml
+++ b/.github/workflows/preview-link.yml
@@ -19,6 +19,6 @@ jobs:
           encoded=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$font_url")
           gh api "repos/${{ github.repository }}/statuses/${sha}" \
             -f state=success \
-            -f target_url="https://ipython.org/xkcd-font/preview.html?font=${encoded}" \
+            -f target_url="https://ipython.org/xkcd-font/xkcd-script/?font=${encoded}" \
             -f description="Click to preview the font from this PR" \
             -f context="Font preview"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It is far less uniform than ``xkcd``, and we think it is therefore more like a t
 
 ![Sample of xkcd-script](xkcd-script/samples/ipsum.png)
 
-You can see the font as a [live preview](https://ipython.github.io/xkcd-font/preview.html), or 
+You can see the font as a [live preview](https://ipython.org/xkcd-font/xkcd-script/), or 
 for more information about the font and how it is constructed see the [xkcd-script/README](xkcd-script/README.md).
 
 Pre-built font files are available directly in this repository:

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>xkcd-font</title>
+<link rel="stylesheet" href="site.css">
+<style>
+.content {
+	font-family: xkcd-script;
+	max-width: 720px;
+	margin: 2em auto;
+	padding: 0 1.5em;
+	font-size: 1.2em;
+	line-height: 1.6;
+}
+.content ul { padding-left: 1.4em; }
+.content li { margin: 0.4em 0; }
+.content a { color: #003366; }
+</style>
+</head>
+<body>
+
+<header class="site-header">
+	<h1>xkcd-font</h1>
+	<p class="summary">Fonts derived from the handwriting of @randallmunroe</p>
+</header>
+
+<div class="content">
+	<p>Demos:</p>
+	<ul>
+		<li><a href="xkcd-script/">xkcd-script live preview</a> — type your own text, share via URL</li>
+		<li><a href="mathjax/">MathJax integration</a> — LaTeX rendered with xkcd-script</li>
+	</ul>
+
+	<p>For the font files, installation instructions, and source, see the
+	<a href="https://github.com/ipython/xkcd-font">ipython/xkcd-font</a> repository on GitHub.
+	Pre-built font files ship with every
+	<a href="https://github.com/ipython/xkcd-font/releases/latest">release</a>.</p>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Follow-up from #106.
I missed some README references, and I had thought that the index.html at the root would be rendered based on the README, as was the case with the previous build process, but this changed when I moved it to a workflow build_type. 